### PR TITLE
Allow specifying tree name for each file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
-## ember-cli-file-creator [![Build Status][travis-badge]][travis-badge-url]  [![Build status][appveyor-badge]][appveyor-badge-url]
-
-# Ember-cli-file-creator
+# ember-cli-file-creator [![Build Status][travis-badge]][travis-badge-url]  [![Build status][appveyor-badge]][appveyor-badge-url]
 
 Add a file into the ember app tree.
 
-This is useful for transforming arbitrary data into a consumable format
+This is useful for transforming arbitrary data into a consumable format.
+
 
 ## Usage
-
-* `npm install --save-dev ember-cli-file-creator`
+    npm install --save-dev ember-cli-file-creator
 
 ```
 var package = require('package');
@@ -17,7 +15,7 @@ EmberApp.init({
 	fileCreator: [
 		{
 			filename: '/service/build-details.js',
-			content: 'export default {' + package.version + '}'
+			content: 'export default {' + package.version + '}',
 		}
 	]
 });
@@ -28,8 +26,29 @@ export default {
 	BUILD_VERSION: '1.2.3'
 };
 ```
-### Functions
-You can also specify a function that will return the content
+
+
+## Available file options
+| Option     | Type                                     | Default value | Use                                   |
+|:-----------|:-----------------------------------------|:--------------|:--------------------------------------|
+| `filename` | String                                   | (required)    | Where to put the file within the tree |
+| `content`  | String or function that returns a string | (required)    | Content of the file                   |
+| `tree`     | String                                   | `"app"`       | Name of the tree to put the file into |
+
+
+## Available trees
+* `app`
+* `styles`
+* `templates`
+* `vendor`
+* `test-support`
+* `public`
+
+See [Ember CLI API docs](https://ember-cli.com/api/classes/Addon.html#method_treeFor) for details.
+
+
+## Passing a function as content
+You can specify a function that must return the content as a string.
 
 ```
 EmberApp.init({

--- a/index.js
+++ b/index.js
@@ -3,14 +3,15 @@ var writeFile = require('broccoli-file-creator');
 var mergeTrees = require('broccoli-merge-trees');
 var concat = require('broccoli-concat');
 
-var cachedTrees = {};
+var cachedTrees;
 
 module.exports = {
     name: 'ember-cli-file-creator',
     init: function() {
-        if (this.hasRun) return;
+        if (this.hasRun) { return; }
         this.hasRun = true;
         this._super.init && this._super.init.apply(this, arguments);
+        cachedTrees = {};
     },
 
     treeFor: function (treeName) {

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var writeFile = require('broccoli-file-creator');
 var mergeTrees = require('broccoli-merge-trees');
 var concat = require('broccoli-concat');
 
-var cachedTree;
+var cachedTrees = {};
 
 module.exports = {
     name: 'ember-cli-file-creator',
@@ -11,15 +11,18 @@ module.exports = {
         if (this.hasRun) return;
         this.hasRun = true;
         this._super.init && this._super.init.apply(this, arguments);
-        cachedTree = null;
     },
 
-    treeForApp: function() {
-        if (cachedTree === null) {
-            cachedTree = mergeTrees(this.options.map(createFile, this));
+    treeFor: function (treeName) {
+        if (!cachedTrees[treeName]) {
+            const currentTreeOptions = this.options.filter(function (option) {
+                return option.tree === treeName || (!option.tree && treeName === 'app');
+            });
+            cachedTrees[treeName] = mergeTrees(currentTreeOptions.map(createFile, this));
         }
-        return cachedTree;
+        return cachedTrees[treeName];
     },
+
     included: function(app) {
         this._super.included(app);
         this.options = app.options.fileCreator || [];


### PR DESCRIPTION
I needed to generate some files into the `public` folder, but this addon only worked with `app`.

Now an optional `tree` property can be passed with every file. It defaults to `app`, so it should be reverse-compatible.

No tests, sorry! I don't have a slightest idea what's going on there. :scream_cat: 